### PR TITLE
Add a few refactors for 3.0.x to 3.1.0 migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 bundles/
 .gradle/
+.idea/

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     compile "io.projectreactor:reactor-core:3.0.3.RELEASE"
     compile 'ch.qos.logback:logback-classic:1.1.8'
     testCompile 'junit:junit:latest.release'
+    testCompile 'org.assertj:assertj-core:3.5.2'
 }
 
 configurations.compile.resolutionStrategy.cacheDynamicVersionsFor 0, 'seconds'

--- a/src/main/java/io/projectreactor/rewrite/AbstractMigrate.java
+++ b/src/main/java/io/projectreactor/rewrite/AbstractMigrate.java
@@ -1,0 +1,50 @@
+package io.projectreactor.rewrite;
+
+import java.io.File;
+
+import com.netflix.rewrite.parse.Parser;
+
+/**
+ * Base class for Reactor migration implementations with utility method to apply
+ * a code migration to a source directory after sanity checks on said directory.
+ *
+ * @author Simon Baslé
+ */
+//TODO tests
+public class AbstractMigrate {
+
+	public static boolean hasGitDir(File dir) {
+		return dir.listFiles(f -> f.isDirectory() && f.getName().equals(".git"))
+				.length == 1;
+	}
+
+	public static boolean hasGitDirSibling(File dir) {
+		return dir.getParentFile().listFiles(f -> f.isDirectory() && f.getName().equals(".git"))
+				.length == 1;
+	}
+
+	public static void checkRecoverable(File rootSourceDirectory) {
+		if (!rootSourceDirectory.isDirectory()) {
+			throw new IllegalArgumentException("Not a directory: " + rootSourceDirectory);
+		}
+
+		if (!hasGitDir(rootSourceDirectory) && !hasGitDirSibling(rootSourceDirectory))
+			throw new IllegalArgumentException("Neither root directory nor its parent has a .git directory");
+	}
+
+	/**
+	 *
+	 * @param rootSourceDirectory the root directory where to find sources to migrate
+	 * @param jdkParser a {@link Parser} used for refactoring that has the correct classpath set up
+	 * @param checkRecoverable set to true to perform sanity checks on the root directory, like does it or its
+	 * parent have a ".git" directory (ensuring the refactored files can be overwritten with a way to revert that)
+	 */
+	public void migrateAll(File rootSourceDirectory, Parser jdkParser, boolean checkRecoverable) {
+		if (checkRecoverable) {
+			checkRecoverable(rootSourceDirectory);
+		}
+
+		//TODO parse all java classes in the source hierarchy, apply the refactors
+	}
+
+}

--- a/src/main/java/io/projectreactor/rewrite/version30x/Migrate306To307.java
+++ b/src/main/java/io/projectreactor/rewrite/version30x/Migrate306To307.java
@@ -1,0 +1,26 @@
+package io.projectreactor.rewrite.version30x;
+
+import com.netflix.rewrite.ast.Tr;
+import com.netflix.rewrite.refactor.Refactor;
+import io.projectreactor.rewrite.AbstractMigrate;
+
+/**
+ * Migrate Reactor code using 3.0.6.RELEASE to code adapted to 3.0.7.RELEASE.
+ *
+ * @author Simon Baslé
+ */
+public class Migrate306To307 extends AbstractMigrate {
+
+	public Tr.CompilationUnit migrateFlatmap(Tr.CompilationUnit a) {
+		Refactor refactor = a.refactor();
+
+		refactor.changeMethodName(a.findMethodCalls("reactor.core.publisher.Mono flatMap(..)"),
+				"flatMapMany");
+
+		refactor.changeMethodName(a.findMethodCalls("reactor.core.publisher.Mono then(java.util.Function)"),
+				"flatMap");
+
+		return refactor.fix();
+	}
+
+}

--- a/src/main/java/io/projectreactor/rewrite/version30x/Migrate306To307.java
+++ b/src/main/java/io/projectreactor/rewrite/version30x/Migrate306To307.java
@@ -17,7 +17,7 @@ public class Migrate306To307 extends AbstractMigrate {
 		refactor.changeMethodName(a.findMethodCalls("reactor.core.publisher.Mono flatMap(..)"),
 				"flatMapMany");
 
-		refactor.changeMethodName(a.findMethodCalls("reactor.core.publisher.Mono then(java.util.Function)"),
+		refactor.changeMethodName(a.findMethodCalls("reactor.core.publisher.Mono then(java.util.function.Function)"),
 				"flatMap");
 
 		return refactor.fix();

--- a/src/main/java/io/projectreactor/rewrite/version31x/Migrate30xTo310.java
+++ b/src/main/java/io/projectreactor/rewrite/version31x/Migrate30xTo310.java
@@ -1,6 +1,7 @@
 package io.projectreactor.rewrite.version31x;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import com.netflix.rewrite.ast.Expression;
@@ -51,16 +52,12 @@ public class Migrate30xTo310 extends AbstractMigrate {
 
 		//FLUX switchOnError is a bit more tricky as it necessitates introducing a lambda
 		for (Tr.MethodInvocation mi : a.findMethodCalls("reactor.core.publisher.Flux switchOnError(..)")) {
-			int pos = -1;
-			int argSize = mi.argExpressions().size();
-			if (argSize == 2) {
-				pos = 1;
-			} else if (argSize == 1) {
-				pos = 0;
-			}
+			final List<Expression> args = mi.argExpressions();
+			int argSize = args.size();
+			int pos = argSize <=2 ? argSize - 1 : -1;
 
 			if (pos >= 0) {
-				String publisher = mi.argExpressions().get(pos).printTrimmed();
+				String publisher = args.get(pos).printTrimmed();
 				String lambda = "t -> " + publisher;
 				refactor.deleteArgument(mi, pos);
 				refactor.insertArgument(mi, pos, lambda);

--- a/src/main/java/io/projectreactor/rewrite/version31x/Migrate30xTo310.java
+++ b/src/main/java/io/projectreactor/rewrite/version31x/Migrate30xTo310.java
@@ -1,0 +1,73 @@
+package io.projectreactor.rewrite.version31x;
+
+import java.util.Iterator;
+import java.util.stream.Collectors;
+
+import com.netflix.rewrite.ast.Expression;
+import com.netflix.rewrite.ast.Tr;
+import com.netflix.rewrite.refactor.Refactor;
+import io.projectreactor.rewrite.AbstractMigrate;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
+
+/**
+ * Migrate Reactor code using 3.0.x releases to code more adapted to 3.1.0.RELEASE,
+ * taking into account methods that were deprecated during 3.0.x and removed in 3.1.0.
+ *
+ * @author Simon Baslé
+ */
+public class Migrate30xTo310 extends AbstractMigrate {
+
+	public Tr.CompilationUnit migrateMonoThenAndFlatmap(Tr.CompilationUnit a) {
+		Refactor refactor = a.refactor();
+
+		refactor.changeMethodName(a.findMethodCalls("reactor.core.publisher.Mono flatMap(..)"),
+				"flatMapMany");
+
+		refactor.changeMethodName(a.findMethodCalls("reactor.core.publisher.Mono then(java.util.function.Function)"),
+				"flatMap");
+
+		return refactor.fix();
+	}
+
+	public Tr.CompilationUnit migrateErrorHandlingOperators(Tr.CompilationUnit a) {
+		Refactor refactor = a.refactor();
+
+		//MONO
+		refactor.changeMethodName(a.findMethodCalls("reactor.core.publisher.Mono otherwise(..)"),
+				"onErrorResume");
+		refactor.changeMethodName(a.findMethodCalls("reactor.core.publisher.Mono otherwiseReturn(..)"),
+				"onErrorReturn");
+		refactor.changeMethodName(a.findMethodCalls("reactor.core.publisher.Mono otherwiseIfEmpty(..)"),
+				"switchIfEmpty");
+		refactor.changeMethodName(a.findMethodCalls("reactor.core.publisher.Mono mapError(..)"),
+				"onErrorMap");
+
+		//FLUX
+		refactor.changeMethodName(a.findMethodCalls("reactor.core.publisher.Flux onErrorResumeWith(..)"),
+				"onErrorResume");
+		refactor.changeMethodName(a.findMethodCalls("reactor.core.publisher.Flux mapError(..)"),
+				"onErrorMap");
+
+		//FLUX switchOnError is a bit more tricky as it necessitates introducing a lambda
+		for (Tr.MethodInvocation mi : a.findMethodCalls("reactor.core.publisher.Flux switchOnError(..)")) {
+			int pos = -1;
+			int argSize = mi.argExpressions().size();
+			if (argSize == 2) {
+				pos = 1;
+			} else if (argSize == 1) {
+				pos = 0;
+			}
+
+			if (pos >= 0) {
+				String publisher = mi.argExpressions().get(pos).printTrimmed();
+				String lambda = "t -> " + publisher;
+				refactor.deleteArgument(mi, pos);
+				refactor.insertArgument(mi, pos, lambda);
+				refactor.changeMethodName(mi, "onErrorResume");
+			}
+		}
+
+		return refactor.fix();
+	}
+}

--- a/src/test/java/io/projectreactor/rewrite/version30x/Migrate306To307Test.java
+++ b/src/test/java/io/projectreactor/rewrite/version30x/Migrate306To307Test.java
@@ -1,0 +1,46 @@
+package io.projectreactor.rewrite.version30x;
+
+import com.netflix.rewrite.ast.Tr;
+import com.netflix.rewrite.parse.OracleJdkParser;
+import com.netflix.rewrite.parse.Parser;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Simon Baslé
+ */
+public class Migrate306To307Test {
+
+	private Parser p = new OracleJdkParser();
+	private Migrate306To307 migrate = new Migrate306To307();
+
+	@Test
+	public void migrateFlatmap() throws Exception {
+		Tr.CompilationUnit a = p.parse("" +
+				"import reactor.core.publisher.*;\n" +
+				"public class A {\n" +
+				"   public void foo() {\n" +
+				"        Mono.just(1).flatMap(n -> Flux.just(n, n + 1));\n" +
+				"        Mono.just(1).then();\n" +
+				"        Mono.just(1).then(Mono.just(2));\n" +
+				"        Mono.just(1).then(a -> Mono.just(a + 2));\n" +
+				"   }\n" +
+				"}");
+
+		String refactored = migrate.migrateFlatmap(a).print();
+
+		assertThat(refactored).isEqualTo("" +
+						"import reactor.core.publisher.*;\n" +
+						"public class A {\n" +
+						"   public void foo() {\n" +
+						"        Mono.just(1).flatMapMany(n -> Flux.just(n, n + 1));\n" +
+						"        Mono.just(1).then();\n" +
+						"        Mono.just(1).then(Mono.just(2));\n" +
+						"        Mono.just(1).flatMap(a -> Mono.just(a + 2));\n" +
+						"   }\n" +
+						"}");
+	}
+
+}

--- a/src/test/java/io/projectreactor/rewrite/version31x/Migrate30xTo310Test.java
+++ b/src/test/java/io/projectreactor/rewrite/version31x/Migrate30xTo310Test.java
@@ -1,0 +1,133 @@
+package io.projectreactor.rewrite.version31x;
+
+import com.netflix.rewrite.ast.Tr;
+import com.netflix.rewrite.parse.OracleJdkParser;
+import com.netflix.rewrite.parse.Parser;
+import io.projectreactor.rewrite.version30x.Migrate306To307;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+
+/**
+ * @author Simon Baslé
+ */
+public class Migrate30xTo310Test {
+
+	private Parser          p       = new OracleJdkParser();
+	private Migrate30xTo310 migrate = new Migrate30xTo310();
+
+	@Test
+	public void migrateMonoThenAndFlatmap() throws Exception {
+		Tr.CompilationUnit a = p.parse("" +
+				"import reactor.core.publisher.*;\n" +
+				"public class A {\n" +
+				"   public void foo() {\n" +
+				"        Mono.just(1).flatMap(n -> Flux.just(n, n + 1));\n" +
+				"        Mono.just(1).then();\n" +
+				"        Mono.just(1).then(Mono.just(2));\n" +
+				"        Mono.just(1).then(a -> Mono.just(a + 2));\n" +
+				"   }\n" +
+				"}");
+
+		String refactored = migrate.migrateMonoThenAndFlatmap(a).print();
+
+		assertThat(refactored).isEqualTo("" +
+				"import reactor.core.publisher.*;\n" +
+				"public class A {\n" +
+				"   public void foo() {\n" +
+				"        Mono.just(1).flatMapMany(n -> Flux.just(n, n + 1));\n" +
+				"        Mono.just(1).then();\n" +
+				"        Mono.just(1).then(Mono.just(2));\n" +
+				"        Mono.just(1).flatMap(a -> Mono.just(a + 2));\n" +
+				"   }\n" +
+				"}");
+	}
+
+	@Test
+	public void migrateFluxSwitchOnError() throws Exception {
+		Tr.CompilationUnit a = p.parse("" +
+				"import reactor.core.publisher.*;\n" +
+				"public class A {\n" +
+				"   public void foo() {\n" +
+				"        Flux.just(1).flatMap(n -> Flux.just(n, n + 1));\n" +
+				"        Flux.just(1).then();\n" +
+				"        Flux.just(1).switchOnError(Mono.just(2));\n" +
+				"        Flux.just(1).switchOnError(IllegalArgumentException.class, Mono.just(2));\n" +
+				"        Flux.just(1).switchOnError(e -> true, Mono.just(2));\n" +
+				"   }\n" +
+				"}");
+
+		String refactored = migrate.migrateErrorHandlingOperators(a).print();
+
+		assertThat(refactored).isEqualTo("" +
+				"import reactor.core.publisher.*;\n" +
+				"public class A {\n" +
+				"   public void foo() {\n" +
+				"        Flux.just(1).flatMap(n -> Flux.just(n, n + 1));\n" +
+				"        Flux.just(1).then();\n" +
+				"        Flux.just(1).onErrorResume(t -> Mono.just(2));\n" +
+				"        Flux.just(1).onErrorResume(IllegalArgumentException.class, t -> Mono.just(2));\n" +
+				"        Flux.just(1).onErrorResume(e -> true, t -> Mono.just(2));\n" +
+				"   }\n" +
+				"}");
+	}
+
+	@Test
+	public void migrateErrorHandlingOperators() throws Exception {
+		Tr.CompilationUnit a = p.parse("" +
+				"import reactor.core.publisher.*;\n" +
+				"public class A {\n" +
+				"   public void foo() {\n" +
+				"        Mono.just(1).otherwise(e -> Mono.just(2));\n" +
+				"        Mono.just(1).otherwise(IllegalArgumentException.class, e -> Mono.just(2));\n" +
+				"        Mono.just(1).otherwise(e -> true, e -> Mono.just(2));\n" +
+				"        Mono.just(1).otherwiseReturn(2);\n" +
+				"        Mono.just(1).otherwiseReturn(IllegalArgumentException.class, 2);\n" +
+				"        Mono.just(1).otherwiseReturn(e -> true, 2);\n" +
+				"        Mono.just(1).otherwiseIfEmpty(Mono.just(2));\n" +
+				"        Mono.just(1).mapError(e -> e);\n" +
+				"        Mono.just(1).mapError(IllegalArgumentException.class, e -> e);\n" +
+				"        Mono.just(1).mapError(e -> true, e -> e);\n" +
+				"        Flux.just(1).onErrorResumeWith(e -> Mono.just(2));\n" +
+				"        Flux.just(1).onErrorResumeWith(IllegalArgumentException.class, e -> Mono.just(2));\n" +
+				"        Flux.just(1).onErrorResumeWith(e -> true, e -> Mono.just(2));\n" +
+				"        Flux.just(1).switchOnError(Mono.just(2));\n" +
+				"        Flux.just(1).switchOnError(IllegalArgumentException.class, Mono.just(2));\n" +
+				"        Flux.just(1).switchOnError(e -> true, Mono.just(2));\n" +
+				"        Flux.just(1).mapError(e -> e);\n" +
+				"        Flux.just(1).mapError(IllegalArgumentException.class, e -> e);\n" +
+				"        Flux.just(1).mapError(e -> true, e -> e);\n" +
+				"   }\n" +
+				"}");
+
+		String refactored = migrate.migrateErrorHandlingOperators(a).print();
+
+		assertThat(refactored).isEqualTo("" +
+				"import reactor.core.publisher.*;\n" +
+				"public class A {\n" +
+				"   public void foo() {\n" +
+				"        Mono.just(1).onErrorResume(e -> Mono.just(2));\n" +
+				"        Mono.just(1).onErrorResume(IllegalArgumentException.class, e -> Mono.just(2));\n" +
+				"        Mono.just(1).onErrorResume(e -> true, e -> Mono.just(2));\n" +
+				"        Mono.just(1).onErrorReturn(2);\n" +
+				"        Mono.just(1).onErrorReturn(IllegalArgumentException.class, 2);\n" +
+				"        Mono.just(1).onErrorReturn(e -> true, 2);\n" +
+				"        Mono.just(1).switchIfEmpty(Mono.just(2));\n" +
+				"        Mono.just(1).onErrorMap(e -> e);\n" +
+				"        Mono.just(1).onErrorMap(IllegalArgumentException.class, e -> e);\n" +
+				"        Mono.just(1).onErrorMap(e -> true, e -> e);\n" +
+				"        Flux.just(1).onErrorResume(e -> Mono.just(2));\n" +
+				"        Flux.just(1).onErrorResume(IllegalArgumentException.class, e -> Mono.just(2));\n" +
+				"        Flux.just(1).onErrorResume(e -> true, e -> Mono.just(2));\n" +
+				"        Flux.just(1).onErrorResume(t -> Mono.just(2));\n" +
+				"        Flux.just(1).onErrorResume(IllegalArgumentException.class, t -> Mono.just(2));\n" +
+				"        Flux.just(1).onErrorResume(e -> true, t -> Mono.just(2));\n" +
+				"        Flux.just(1).onErrorMap(e -> e);\n" +
+				"        Flux.just(1).onErrorMap(IllegalArgumentException.class, e -> e);\n" +
+				"        Flux.just(1).onErrorMap(e -> true, e -> e);\n" +
+				"   }\n" +
+				"}");
+	}
+
+}


### PR DESCRIPTION
Hey @jkschneider! I played a little with `rewrite` and started implementing some refactors that help migrate Reactor code from using 3.0.x (namely 3.0.7.BUILD-SNAPSHOT) to code ready for 3.1.0...

Let me know if you see better ways of refactoring method input params (here we have a method that previously took a `Publisher` and now is replaced by another method that instead takes a `Function<Throwable, Publisher>` basically).